### PR TITLE
Camera Wobbles & Vessel Sound disablement in IVA

### DIFF
--- a/ProbeControlRoom/ProbeControlRoom.cs
+++ b/ProbeControlRoom/ProbeControlRoom.cs
@@ -18,6 +18,16 @@ namespace ProbeControlRoom
 		private Part aPart;
 		private Part aPartRestartTo = null;
 
+		float shipVolumeBackup = GameSettings.SHIP_VOLUME;
+		float ambianceVolumeBackup = GameSettings.AMBIENCE_VOLUME;
+		//float musicVolumeBackup = GameSettings.MUSIC_VOLUME;
+		//float uiVolumeBackup = GameSettings.UI_VOLUME;
+		//float voiceVolumeBackup = GameSettings.VOICE_VOLUME;
+		
+		float cameraWobbleBackup = GameSettings.FLT_CAMERA_WOBBLE;
+		float cameraFXInternalBackup = GameSettings.CAMERA_FX_INTERNAL;
+		float cameraFXExternalBackup = GameSettings.CAMERA_FX_EXTERNAL;
+
 
 		public void Start()
 		{
@@ -35,6 +45,24 @@ namespace ProbeControlRoom
 
 		public void OnDestroy()
 		{
+			//in case of revert to launch while in IVA, Update() won't detect it
+			//and startIVA(p) will be called without prior stopIVA
+			//which will cause settings to be lost forever
+			//OnDestroy() will be called though
+
+			//re-enable sound
+			GameSettings.SHIP_VOLUME = shipVolumeBackup;
+			GameSettings.AMBIENCE_VOLUME = ambianceVolumeBackup;
+			//GameSettings.MUSIC_VOLUME = musicVolumeBackup;
+			//GameSettings.UI_VOLUME = uiVolumeBackup;
+			//GameSettings.VOICE_VOLUME = voiceVolumeBackup;
+
+			//re-enable camera wobble
+			GameSettings.FLT_CAMERA_WOBBLE = cameraWobbleBackup;
+			GameSettings.CAMERA_FX_INTERNAL = cameraFXInternalBackup;
+			GameSettings.CAMERA_FX_EXTERNAL = cameraFXExternalBackup;
+
+
 			ProbeControlRoomUtils.Logger.debug ("[ProbeControlRoom] OnDestroy()");
 			GameEvents.onVesselChange.Remove(OnVesselChange);
 			GameEvents.onVesselWasModified.Remove(OnVesselModified);
@@ -103,6 +131,29 @@ namespace ProbeControlRoom
 
 				ProbeControlRoomUtils.Logger.debug ("[ProbeControlRoom] startIVA(Part) - fire up IVA");
 
+				//disable sound
+				shipVolumeBackup = GameSettings.SHIP_VOLUME;
+				ambianceVolumeBackup = GameSettings.AMBIENCE_VOLUME;
+				//musicVolumeBackup = GameSettings.MUSIC_VOLUME;
+				//uiVolumeBackup = GameSettings.UI_VOLUME;
+				//voiceVolumeBackup = GameSettings.VOICE_VOLUME;
+
+				GameSettings.SHIP_VOLUME = 0;
+				GameSettings.AMBIENCE_VOLUME = 0;
+				//GameSettings.MUSIC_VOLUME = 0;
+				//GameSettings.UI_VOLUME = 0;
+				//GameSettings.VOICE_VOLUME = 0;
+
+				//disable camera wobble
+				cameraWobbleBackup = GameSettings.FLT_CAMERA_WOBBLE;
+				cameraFXInternalBackup = GameSettings.CAMERA_FX_INTERNAL;
+				cameraFXExternalBackup = GameSettings.CAMERA_FX_EXTERNAL;
+
+				GameSettings.FLT_CAMERA_WOBBLE = 0;
+				GameSettings.CAMERA_FX_INTERNAL = 0;
+				GameSettings.CAMERA_FX_EXTERNAL = 0;
+
+
 				CameraManager.ICameras_DeactivateAll ();
 
 				FlightCamera.fetch.EnableCamera ();
@@ -142,6 +193,19 @@ namespace ProbeControlRoom
 			isActive = false;
 			aModule = null;
 			aPart = null;
+
+			//re-enable sound
+			GameSettings.SHIP_VOLUME = shipVolumeBackup;
+			GameSettings.AMBIENCE_VOLUME = ambianceVolumeBackup;
+			//GameSettings.MUSIC_VOLUME = musicVolumeBackup;
+			//GameSettings.UI_VOLUME = uiVolumeBackup;
+			//GameSettings.VOICE_VOLUME = voiceVolumeBackup;
+
+			//re-enable camera wobble
+			GameSettings.FLT_CAMERA_WOBBLE = cameraWobbleBackup;
+			GameSettings.CAMERA_FX_INTERNAL = cameraFXInternalBackup;
+			GameSettings.CAMERA_FX_EXTERNAL = cameraFXExternalBackup;
+
 			CameraManager.ICameras_DeactivateAll ();
 
 			CameraManager.Instance.SetCameraFlight();

--- a/ProbeControlRoom/ProbeControlRoom.csproj
+++ b/ProbeControlRoom/ProbeControlRoom.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -38,20 +38,22 @@
     </CustomCommands>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\..\..\..\..\Program Files %28x86%29\Steam\SteamApps\common\Kerbal Space Program\KSP_Data\Managed\Assembly-CSharp.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine">
-      <HintPath>..\..\..\..\..\..\Program Files %28x86%29\Steam\SteamApps\common\Kerbal Space Program\KSP_Data\Managed\UnityEngine.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-  <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ProbeControlRoom.cs" />
     <Compile Include="ProbeControlRoomPart.cs" />
     <Compile Include="ProbeControlRoomUI.cs" />
     <Compile Include="ProbeControlRoomUtils.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Assembly-CSharp">
+      <HintPath>..\..\..\..\..\..\..\Program Files %28x86%29\Steam\SteamApps\common\Kerbal Space Program\KSP_Data\Managed\Assembly-CSharp.dll</HintPath>
+    </Reference>
+    <Reference Include="System">
+      <HintPath>..\..\..\..\..\..\..\Program Files %28x86%29\Steam\SteamApps\common\Kerbal Space Program\KSP_Data\Managed\System.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine">
+      <HintPath>..\..\..\..\..\..\..\Program Files %28x86%29\Steam\SteamApps\common\Kerbal Space Program\KSP_Data\Managed\UnityEngine.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
Removed camera wobbles and vessel sounds when in IVA by modifying the game
settings directly and restoring them when going out of IVA or restarting
flight.

Known bugs :
-Game Settings don't recover when game crashes (but they do when Alt+F4,
the only problem is when the process gets killed brutally)
-Some sounds like the staging sound for example can't be disabled. I think
this is a bug from Squad. Funilly enough, these sounds' volume seems to
be proportional to atmosphere density around the vessel. PCR IVA buttons
seem to be affected by this.
